### PR TITLE
Fix for OSX build

### DIFF
--- a/buildosx/InstallOSX/climatology_pi.pkgproj.in
+++ b/buildosx/InstallOSX/climatology_pi.pkgproj.in
@@ -74,23 +74,56 @@
 												</dict>
 												<dict>
 													<key>CHILDREN</key>
+													<array/>
+													<key>GID</key>
+													<integer>80</integer>
+													<key>PATH</key>
+													<string>Resources</string>
+													<key>PATH_TYPE</key>
+													<integer>3</integer>
+													<key>PERMISSIONS</key>
+													<integer>493</integer>
+													<key>TYPE</key>
+													<integer>3</integer>
+													<key>UID</key>
+													<integer>0</integer>
+												</dict>
+												<dict>
+													<key>CHILDREN</key>
 													<array>
 														<dict>
 															<key>CHILDREN</key>
 															<array>
 																<dict>
 																	<key>CHILDREN</key>
-																	<array/>
+																	<array>
+																		<dict>
+																			<key>CHILDREN</key>
+																			<array/>
+																			<key>GID</key>
+																			<integer>80</integer>
+																			<key>PATH</key>
+																			<string>../data</string>
+																			<key>PATH_TYPE</key>
+																			<integer>3</integer>
+																			<key>PERMISSIONS</key>
+																			<integer>493</integer>
+																			<key>TYPE</key>
+																			<integer>3</integer>
+																			<key>UID</key>
+																			<integer>0</integer>
+																		</dict>
+																	</array>
 																	<key>GID</key>
 																	<integer>80</integer>
 																	<key>PATH</key>
-																	<string>Resources/fr.lproj/opencpn-${PACKAGE_NAME}.mo</string>
+																	<string>${PACKAGE_NAME}</string>
 																	<key>PATH_TYPE</key>
-																	<integer>3</integer>
+																	<integer>0</integer>
 																	<key>PERMISSIONS</key>
-																	<integer>420</integer>
+																	<integer>509</integer>
 																	<key>TYPE</key>
-																	<integer>3</integer>
+																	<integer>2</integer>
 																	<key>UID</key>
 																	<integer>0</integer>
 																</dict>
@@ -98,7 +131,7 @@
 															<key>GID</key>
 															<integer>80</integer>
 															<key>PATH</key>
-															<string>fr.lproj</string>
+															<string>plugins</string>
 															<key>PATH_TYPE</key>
 															<integer>0</integer>
 															<key>PERMISSIONS</key>
@@ -112,7 +145,7 @@
 													<key>GID</key>
 													<integer>80</integer>
 													<key>PATH</key>
-													<string>Resources</string>
+													<string>SharedSupport</string>
 													<key>PATH_TYPE</key>
 													<integer>0</integer>
 													<key>PERMISSIONS</key>
@@ -648,15 +681,15 @@
 				<integer>4</integer>
 				<key>BACKGROUND_PATH</key>
 				<dict>
-                                        <key>PATH</key>
-                                        <string>pkg_background.jpg</string>
-                                        <key>PATH_TYPE</key>
-                                        <integer>1</integer>
-                                </dict>
-                                <key>CUSTOM</key>
-                                <integer>1</integer>
-                                <key>SCALING</key>
-                                <integer>1</integer>
+					<key>PATH</key>
+					<string>pkg_background.jpg</string>
+					<key>PATH_TYPE</key>
+					<integer>1</integer>
+				</dict>
+				<key>CUSTOM</key>
+				<integer>1</integer>
+				<key>SCALING</key>
+				<integer>1</integer>
 			</dict>
 			<key>INSTALLATION TYPE</key>
 			<dict>


### PR DESCRIPTION
Data files in climatology_pi/data are now included in the build
Changed Resources build so now all language files are auto included
in the build.