### PR TITLE
Close event

### DIFF
--- a/Climatology.fbp
+++ b/Climatology.fbp
@@ -61,7 +61,7 @@
             <event name="OnAuiPaneRestore"></event>
             <event name="OnAuiRender"></event>
             <event name="OnChar"></event>
-            <event name="OnClose"></event>
+            <event name="OnClose">OnClose</event>
             <event name="OnEnterWindow"></event>
             <event name="OnEraseBackground"></event>
             <event name="OnHibernate"></event>

--- a/src/ClimatologyUI.cpp
+++ b/src/ClimatologyUI.cpp
@@ -196,6 +196,7 @@ ClimatologyDialogBase::ClimatologyDialogBase( wxWindow* parent, wxWindowID id, c
 	this->Centre( wxBOTH );
 	
 	// Connect Events
+	this->Connect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( ClimatologyDialogBase::OnClose ) );
 	m_cMonth->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( ClimatologyDialogBase::OnMonth ), NULL, this );
 	m_sDay->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ClimatologyDialogBase::OnDay ), NULL, this );
 	m_cbAll->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnAll ), NULL, this );
@@ -228,6 +229,7 @@ ClimatologyDialogBase::ClimatologyDialogBase( wxWindow* parent, wxWindowID id, c
 ClimatologyDialogBase::~ClimatologyDialogBase()
 {
 	// Disconnect Events
+	this->Disconnect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( ClimatologyDialogBase::OnClose ) );
 	m_cMonth->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( ClimatologyDialogBase::OnMonth ), NULL, this );
 	m_sDay->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ClimatologyDialogBase::OnDay ), NULL, this );
 	m_cbAll->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnAll ), NULL, this );

--- a/src/ClimatologyUI.h
+++ b/src/ClimatologyUI.h
@@ -64,6 +64,7 @@ class ClimatologyDialogBase : public wxDialog
 		wxButton* m_bConfig;
 		
 		// Virtual event handlers, overide them in your derived class
+		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
 		virtual void OnMonth( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnDay( wxSpinEvent& event ) { event.Skip(); }
 		virtual void OnAll( wxCommandEvent& event ) { event.Skip(); }

--- a/src/climatology_pi.cpp
+++ b/src/climatology_pi.cpp
@@ -274,9 +274,12 @@ void climatology_pi::OnToolbarToolCallback(int id)
 
 void climatology_pi::OnClimatologyDialogClose()
 {
-    if(m_pClimatologyDialog)
+    if(m_pClimatologyDialog) {
+        if(m_pClimatologyDialog->m_cfgdlg)
+            m_pClimatologyDialog->m_cfgdlg->Hide();
         m_pClimatologyDialog->Show(false);
-
+        RequestRefresh(m_parent_window); // refresh main window
+    }
     SaveConfig();
 }
 


### PR DESCRIPTION
Hi

- Without the base class declaration event handler is never called in derived class.
There's both wxform source and generated files.

- do the same things when closing climatology main dialog box than when clicking on toolbar.

Regards
Didier
