### PR TITLE
use climatology time as source (WIP for weather routing)

### DIFF
--- a/src/ClimatologyDialog.h
+++ b/src/ClimatologyDialog.h
@@ -64,6 +64,7 @@ public:
 
     ClimatologyConfigDialog *m_cfgdlg;
     climatology_pi *pPlugIn;
+    bool Show(bool show);
 
 private:
     wxCheckBox *GetSettingControl(int setting);

--- a/src/climatology_pi.cpp
+++ b/src/climatology_pi.cpp
@@ -335,6 +335,33 @@ void climatology_pi::SetPluginMessage(wxString &message_id, wxString &message_bo
     }
 }
 
+// -------------------------------------------------------
+// GRIB_TIMELINE is a misnomer
+void climatology_pi::SendTimelineMessage(wxDateTime time)
+{
+    wxJSONValue v;
+    if (time.IsValid()) {
+        v[_T("Day")] = time.GetDay();
+        v[_T("Month")] = time.GetMonth();
+        v[_T("Year")] = time.GetYear();
+        v[_T("Hour")] = time.GetHour();
+        v[_T("Minute")] = time.GetMinute();
+        v[_T("Second")] = time.GetSecond();
+    }
+    else {
+        v[_T("Day")] = -1;
+        v[_T("Month")] = -1;
+        v[_T("Year")] = -1;
+        v[_T("Hour")] = -1;
+        v[_T("Minute")] = -1;
+        v[_T("Second")] = -1;
+    }
+    wxJSONWriter w;
+    wxString out;
+    w.Write(v, out);
+    SendPluginMessage(wxString(_T("GRIB_TIMELINE")), out);
+}
+
 void climatology_pi::FreeData()
 {
     delete g_pOverlayFactory;

--- a/src/climatology_pi.h
+++ b/src/climatology_pi.h
@@ -98,6 +98,7 @@ public:
       void SetColorScheme(PI_ColorScheme cs);
 
       void OnClimatologyDialogClose();
+      void SendTimelineMessage(wxDateTime time);
 
 private:
       void FreeData();


### PR DESCRIPTION
Hi
Mainly for testing and comments.

Grib plugin can 'pilot' weather routing track boat position. 
Do the same with climatology.

May have some side effects with both of them are used.

Regards
Didier

