### PR TITLE
backport json from weather routing

### DIFF
--- a/src/wxJSON/jsonreader.cpp
+++ b/src/wxJSON/jsonreader.cpp
@@ -8,8 +8,14 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
-#ifdef __GNUG__
-    #pragma implementation "jsonreader.cpp"
+//#ifdef __GNUG__
+//    #pragma implementation "jsonreader.cpp"
+//#endif
+
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
 #endif
 
 #include "jsonreader.h"
@@ -18,7 +24,6 @@
 #include <wx/sstream.h>
 #include <wx/debug.h>
 #include <wx/log.h>
-
 
 
 /*! \class wxJSONReader
@@ -171,9 +176,10 @@
 // trace messages by setting the:
 // WXTRACE=traceReader StoreComment
 // environment variable
+#if wxDEBUG_LEVEL > 0
 static const wxChar* traceMask = _T("traceReader");
 static const wxChar* storeTraceMask = _T("StoreComment");
-
+#endif
 
 //! Ctor
 /*!
@@ -1971,26 +1977,28 @@ wxJSONReader::Strtoll( const wxString& str, wxInt64* i64 )
     wxUint64 ui64;
     bool r = DoStrto_ll( str, &ui64, &sign );
 
-    // check overflow for signed long long
-    switch ( sign )  {
-        case '-' :
-            if ( ui64 > (wxUint64) LLONG_MAX + 1 )  {
-                r = false;
-            }
-            else  {
-                *i64 = (wxInt64) (ui64 * -1);
-            }
-            break;
+    if ( r) {
+        // check overflow for signed long long
+        switch ( sign )  {
+            case '-' :
+                if ( ui64 > (wxUint64) LLONG_MAX + 1 )  {
+                    r = false;
+                }
+                else  {
+                    *i64 = (wxInt64) (ui64 * -1);
+                }
+                break;
 
-        // case '+' :
-        default :
-            if ( ui64 > LLONG_MAX )  {
-                r = false;
-            }
-            else  {
-                *i64 = (wxInt64) ui64;
-            }
-            break;
+            // case '+' :
+            default :
+                if ( ui64 > LLONG_MAX )  {
+                    r = false;
+                }
+                else  {
+                    *i64 = (wxInt64) ui64;
+                }
+                break;
+        }
     }
     return r;
 }

--- a/src/wxJSON/jsonreader.h
+++ b/src/wxJSON/jsonreader.h
@@ -11,9 +11,9 @@
 #if !defined( _WX_JSONREADER_H )
 #define _WX_JSONREADER_H
 
-#ifdef __GNUG__
-    #pragma interface "jsonreader.h"
-#endif
+//#ifdef __GNUG__
+//    #pragma interface "jsonreader.h"
+//#endif
 
 // For compilers that support precompilation, includes "wx/wx.h".
 #include "wx/wxprec.h"

--- a/src/wxJSON/jsonval.cpp
+++ b/src/wxJSON/jsonval.cpp
@@ -8,10 +8,15 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
-#ifdef __GNUG__
-    #pragma implementation "jsonval.cpp"
-#endif
+//#ifdef __GNUG__
+//    #pragma implementation "jsonval.cpp"
+//#endif
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including wx/debug.h (also included by wx/wxprec.h)
+#define wxDEBUG_LEVEL 0
+#endif
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
@@ -20,8 +25,8 @@
 #pragma hdrstop
 #endif
 
+
 #include <wx/log.h>
-#include <wx/debug.h>
 #include <wx/arrimpl.cpp>
 
 #include "jsonval.h"
@@ -29,13 +34,19 @@
 
 WX_DEFINE_OBJARRAY( wxJSONInternalArray );
 
+#if wxCHECK_VERSION(3, 0, 0)
+#define compatibleLongLongFmtSpec _T(wxLongLongFmtSpec)
+#else
+#define compatibleLongLongFmtSpec wxLongLongFmtSpec
+#endif
 
+#if wxDEBUG_LEVEL > 0
 // the trace mask used in wxLogTrace() function
 // static const wxChar* traceMask = _T("jsonval");
 static const wxChar* traceMask = _T("jsonval");
 static const wxChar* compareTraceMask = _T("sameas");
 static const wxChar* cowTraceMask = _T("traceCOW" );
-
+#endif
 
 
 /*******************************************************************
@@ -962,7 +973,7 @@ wxJSONValue::AsString() const
             break;
         case wxJSONTYPE_INT :
             #if defined( wxJSON_64BIT_INT )
-                  s.Printf( _T("%") wxLongLongFmtSpec _T("i"),
+            s.Printf( _T("%") compatibleLongLongFmtSpec _T("i"),
                         data->m_value.m_valInt64 );
             #else
             s.Printf( _T("%ld"), data->m_value.m_valLong );
@@ -970,7 +981,7 @@ wxJSONValue::AsString() const
             break;
         case wxJSONTYPE_UINT :
             #if defined( wxJSON_64BIT_INT )
-            s.Printf( _T("%") wxLongLongFmtSpec _T("u"),
+            s.Printf( _T("%") compatibleLongLongFmtSpec _T("u"),
                         data->m_value.m_valUInt64 );
             #else
             s.Printf( _T("%lu"), data->m_value.m_valULong );
@@ -1815,8 +1826,10 @@ wxJSONValue&
 wxJSONValue::Item( const wxString& key )
 {
     wxLogTrace( traceMask, _T("(%s) searched key=\'%s\'"), __PRETTY_FUNCTION__, key.c_str());
+#if !wxCHECK_VERSION(2,9,0)
     wxLogTrace( traceMask, _T("(%s) actual object: %s"), __PRETTY_FUNCTION__, GetInfo().c_str());
-
+#endif
+    
     wxJSONRefData* data = COW();
     wxJSON_ASSERT( data );
 
@@ -1864,8 +1877,10 @@ wxJSONValue
 wxJSONValue::ItemAt( const wxString& key ) const
 {
     wxLogTrace( traceMask, _T("(%s) searched key=\'%s\'"), __PRETTY_FUNCTION__, key.c_str());
+#ifndef __WXOSX__
     wxLogTrace( traceMask, _T("(%s) actual object: %s"), __PRETTY_FUNCTION__, GetInfo().c_str());
-
+#endif
+    
     wxJSONRefData* data = GetRefData();
     wxJSON_ASSERT( data );
 

--- a/src/wxJSON/jsonval.h
+++ b/src/wxJSON/jsonval.h
@@ -11,9 +11,9 @@
 #if !defined( _WX_JSONVAL_H )
 #define _WX_JSONVAL_H
 
-#ifdef __GNUG__
-    #pragma interface "jsonval.h"
-#endif
+//#ifdef __GNUG__
+//    #pragma interface "jsonval.h"
+//#endif
 
 // For compilers that support precompilation, includes "wx/wx.h".
 #include "wx/wxprec.h"

--- a/src/wxJSON/jsonwriter.cpp
+++ b/src/wxJSON/jsonwriter.cpp
@@ -8,10 +8,15 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
-#ifdef __GNUG__
-    #pragma implementation "jsonwriter.cpp"
-#endif
+//#ifdef __GNUG__
+//    #pragma implementation "jsonwriter.cpp"
+//#endif
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
 
 #include "jsonwriter.h"
 
@@ -20,7 +25,9 @@
 #include <wx/debug.h>
 #include <wx/log.h>
 
+#if wxDEBUG_LEVEL > 0
 static const wxChar* writerTraceMask = _T("traceWriter");
+#endif
 
 /*! \class wxJSONWriter
  \brief The JSON document writer

--- a/src/wxJSON/jsonwriter.h
+++ b/src/wxJSON/jsonwriter.h
@@ -11,9 +11,9 @@
 #if !defined( _WX_JSONWRITER_H )
 #define _WX_JSONWRITER_H
 
-#ifdef __GNUG__
-    #pragma interface "jsonwriter.h"
-#endif
+//#ifdef __GNUG__
+//    #pragma interface "jsonwriter.h"
+//#endif
 
 // For compilers that support precompilation, includes "wx/wx.h".
 #include "wx/wxprec.h"


### PR DESCRIPTION
Hi, 

One of my  previous PRs triggers a latent bug in old JSON code used by climatology_pi and it doesn't compile on window.
This PR copy and paste working wxjson source code from weather_routing (it does compile on windows, tested)

Regards
Didier
