### PR TITLE
Use a wxGenericProgressDialog rather than a wxProgressDialog

### DIFF
--- a/src/ClimatologyOverlayFactory.cpp
+++ b/src/ClimatologyOverlayFactory.cpp
@@ -507,7 +507,7 @@ wxColour ClimatologyOverlayFactory::GetGraphicColor(int setting, double val_in)
     return *wxBLACK; /* unreachable */
 }
 
-void ClimatologyOverlayFactory::LoadInternal(wxProgressDialog *progressdialog)
+void ClimatologyOverlayFactory::LoadInternal(wxGenericProgressDialog *progressdialog)
 {
     wxString fmt = "%02d";
 
@@ -625,8 +625,8 @@ void ClimatologyOverlayFactory::Load()
     Free();
     m_FailedFiles.clear();
     
-    wxProgressDialog *progressdialog = nullptr;
-    progressdialog = new wxProgressDialog( _("Climatology"), wxString(), 38, &m_dlg,
+    wxGenericProgressDialog *progressdialog = nullptr;
+    progressdialog = new wxGenericProgressDialog( _("Climatology"), wxString(), 38, &m_dlg,
                                      wxPD_CAN_ABORT | wxPD_ELAPSED_TIME );
     LoadInternal(progressdialog);
     progressdialog->Destroy();

--- a/src/ClimatologyOverlayFactory.h
+++ b/src/ClimatologyOverlayFactory.h
@@ -235,7 +235,7 @@ public:
 
 private:
     void Load();
-    void LoadInternal(wxProgressDialog *progressdialog);
+    void LoadInternal(wxGenericProgressDialog *progressdialog);
     void Free();
 
     void ReadWindData(int month, wxString filename);


### PR DESCRIPTION
Hi,

Either there's a bug in wx 3.1 or we don't understand how to use it safely,
but on Windows wxProgressDialog is broken.

works with wine, don't know on actual windows box.

Regards
Didier