### PR TITLE
Ov50 - Fix wind rose font size

### DIFF
--- a/src/ClimatologyOverlayFactory.cpp
+++ b/src/ClimatologyOverlayFactory.cpp
@@ -2726,6 +2726,9 @@ bool ClimatologyOverlayFactory::RenderOverlay( piDC &dc, PlugIn_ViewPort &vp )
         glEnable( GL_BLEND );
     }
 
+wxFont font( 8, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL );
++    m_dc->SetFont( font );
+
     for(int overlay = 1; overlay >= 0; overlay--)
     for(int i=0; i<ClimatologyOverlaySettings::SETTINGS_COUNT; i++) {
         if(!m_dlg.SettingEnabled(i))

--- a/src/ClimatologyOverlayFactory.cpp
+++ b/src/ClimatologyOverlayFactory.cpp
@@ -2727,7 +2727,7 @@ bool ClimatologyOverlayFactory::RenderOverlay( piDC &dc, PlugIn_ViewPort &vp )
     }
 
 wxFont font( 8, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL );
-+    m_dc->SetFont( font );
+m_dc->SetFont( font );
 
     for(int overlay = 1; overlay >= 0; overlay--)
     for(int i=0; i<ClimatologyOverlaySettings::SETTINGS_COUNT; i++) {


### PR DESCRIPTION

[clima-fontsize-patch.txt](https://github.com/seandepagnier/climatology_pi/files/3042783/clima-fontsize-patch.txt)
In Windows the wind rose font size is too big and obscured. This fixes it.
From Stelian's diff file with the change.  ClimatologyOverlayFactory.cpp